### PR TITLE
add methods to close rpc clients

### DIFF
--- a/common/remote.go
+++ b/common/remote.go
@@ -64,3 +64,7 @@ func (self Remote) Call(service string, args, reply interface{}) error {
 func (self Remote) Go(service string, args, reply interface{}) *rpc.Call {
   return Switch.Go(self.Addr, service, args, reply)
 }
+
+func (self Remote) Close() error {
+  return Switch.Close(self.Addr)
+}

--- a/common/switchboard.go
+++ b/common/switchboard.go
@@ -61,3 +61,12 @@ func (self *Switchboard) Call(addr, service string, args, reply interface{}) (er
 	}
 	return
 }
+
+func (self *Switchboard) Close(addr string) error {
+  client, err := self.client(addr)
+  if err != nil {
+    return err
+  }
+  
+  return client.Close()
+}


### PR DESCRIPTION
Shutting down server nodes when holding rpc client connections results in "rpc: client protocol error: unexpected EOF". It would require to close relevant rpc clients beforehand. As far as I could see, this is currently not possible. Adding these methods or simply exporting clients in switchboard would help. Thanks.
