### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -361,7 +361,7 @@ func (self *Conn) SubClear(key []byte) {
 	self.subClear(key, false)
 }
 
-// SubClear will remove all byte values from the sub tree defined by key. It will retain delete markers for all deleted values.
+// SSubClear will remove all byte values from the sub tree defined by key. It will retain delete markers for all deleted values.
 func (self *Conn) SSubClear(key []byte) {
 	self.subClear(key, true)
 }
@@ -754,7 +754,7 @@ func (self *Conn) ReverseSlice(key, min, max []byte, mininc, maxinc bool) (resul
 	return
 }
 
-// ReverseSlice will return the slice between min and max in the sub tree defined by key.
+// Slice will return the slice between min and max in the sub tree defined by key.
 // A min of nil will return from the start. A max of nil will return to the end.
 func (self *Conn) Slice(key, min, max []byte, mininc, maxinc bool) (result []common.Item) {
 	r := common.Range{
@@ -805,7 +805,7 @@ func (self *Conn) SubMirrorPrev(key, subKey []byte) (prevKey, prevValue []byte, 
 	return
 }
 
-// SubMirrorPrev will return the next key and value after subKey in the sub tree defined by key.
+// SubMirrorNext will return the next key and value after subKey in the sub tree defined by key.
 func (self *Conn) SubMirrorNext(key, subKey []byte) (nextKey, nextValue []byte, existed bool) {
 	data := common.Item{
 		Key:    key,
@@ -919,7 +919,7 @@ func (self *Conn) DescribeTree(pos []byte) (result string, err error) {
 	return
 }
 
-// DescribeTree will return a string representation of the complete trees of all known nodes.
+// DescribeAllTrees will return a string representation of the complete trees of all known nodes.
 // Used for debug purposes, don't do it on big databases!
 func (self *Conn) DescribeAllTrees() string {
 	buf := new(bytes.Buffer)
@@ -1030,7 +1030,7 @@ func (self *Conn) Configuration() (conf map[string]string) {
 	return result.Data
 }
 
-// SubConfiguratino will return the configuration for the sub tree defined by key.
+// SubConfiguration will return the configuration for the sub tree defined by key.
 //
 // mirrored=yes means that the sub tree is currently mirrored.
 func (self *Conn) SubConfiguration(key []byte) (conf map[string]string) {

--- a/dhash/dhash.go
+++ b/dhash/dhash.go
@@ -81,7 +81,7 @@ func NewNode(listenAddr, broadcastAddr string) *Node {
 	return NewNodeDir(listenAddr, broadcastAddr, broadcastAddr)
 }
 
-// NewNode will return a dhash.Node publishing itself on the given address.
+// NewNodeDir will return a dhash.Node publishing itself on the given address.
 func NewNodeDir(listenAddr, broadcastAddr, dir string) (result *Node) {
 	result = &Node{
 		node:          discord.NewNode(listenAddr, broadcastAddr),

--- a/discord/node.go
+++ b/discord/node.go
@@ -369,7 +369,7 @@ func (self *Node) GetSuccessor() common.Remote {
 	return self.GetSuccessorForRemote(self.Remote())
 }
 
-// GetSuccessorFor will return the successor for the provided remote.
+// GetSuccessorForRemote will return the successor for the provided remote.
 func (self *Node) GetSuccessorForRemote(r common.Remote) common.Remote {
 	return self.ring.Successor(r)
 }

--- a/radix/tree.go
+++ b/radix/tree.go
@@ -391,7 +391,7 @@ func (self *Tree) MirrorReverseIndexOf(key []byte) (index int, existed bool) {
 	return
 }
 
-// MirrorReverseIndexOf will return the index from the end (or the index it would have if it existed) key.
+// ReverseIndexOf will return the index from the end (or the index it would have if it existed) key.
 func (self *Tree) ReverseIndexOf(key []byte) (index int, existed bool) {
 	if self == nil {
 		return


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._